### PR TITLE
[codex] Make WeChat archive script safer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.test_tmp/
+tmp*/
+archive_wechat_file.log

--- a/README.md
+++ b/README.md
@@ -3,48 +3,64 @@
 ## 效果
 
 ### 整理后的文件
+
 ![img_1.png](img_1.png)
+
 ## 功能
 
-该程序是为了解决Mac版微信中接收和发送的文件按联系人分类、文件夹命名混乱的问题。它能够将所有接收和发送的文件以及图片移动至指定文件夹，并按日期进行分类。
+这个脚本用于整理 Mac 版微信接收和发送的文件。它会扫描微信目录下的 `File` 和 `OpenData` 文件夹，把文件复制到目标目录，并按月份归档。
 
-| 文件状态 | 操作 | status |
-|:------------:|:-------:|:---------:|
-| 相同名称，不同MD5 | 重命名并复制 | 1 |
-| 不同名称，不同MD5 | 直接复制 | 3 |
-| 不同名称，相同MD5 | 直接复制 | 3 |
-| 相同名称，相同MD5 | 跳过 | 2 |
+归档过程中会按 MD5 做内容去重，避免同一份文件被重复备份。
+
+| 文件状态 | 操作 |
+|:--:|:--:|
+| 目标目录已有相同 MD5 | 跳过 |
+| 同月份存在同名但不同内容的文件 | 使用 MD5 后缀改名后复制 |
+| 目标目录没有相同内容且没有同名冲突 | 直接复制 |
+| 文件最近还在变动 | 跳过，避免复制未写完的文件 |
 
 ## 使用说明
 
-在使用前，需要正确设置以下三个路径：
+建议先使用 `--dry-run` 预演，确认计划没有问题后再正式执行。
 
-1. `root_dir`: 微信文件所在的路径，末尾不需要加 `/`。
+```bash
+python archive_wechat_file.py \
+  --root-dir "/path/to/your/wechat/files" \
+  --target-dir "/path/to/your/archive" \
+  --dry-run
+```
 
-    示例: 
-    ```python
-    root_dir = '/path/to/your/wechat/files'
-    ```
+正式执行：
 
-2. `transit_path`: 文件的中转站路径，末尾需要加 `/`。
+```bash
+python archive_wechat_file.py \
+  --root-dir "/path/to/your/wechat/files" \
+  --target-dir "/path/to/your/archive"
+```
 
-    示例:
-    ```python
-    transit_path = '/path/to/your/transit/path/'
-    ```
+默认会跳过最近 5 秒内修改过的文件，减少复制微信仍在写入的半截文件的风险。可以用 `--stable-seconds` 调整：
 
-3. `target_path2`: 用于存储复制过来的文件的目标目录，末尾需要加 `/`。
+```bash
+python archive_wechat_file.py \
+  --root-dir "/path/to/your/wechat/files" \
+  --target-dir "/path/to/your/archive" \
+  --stable-seconds 10
+```
 
-    示例:
-    ```python
-    target_path2 = '/path/to/your/target/path/'
-    ```
-请务必将以上路径替换为实际使用的路径。
+脚本会把日志写到目标目录下的 `archive_wechat_file.log`。也可以通过 `--log-file` 指定日志路径。
 
-## 特色
+如果不想每次输入参数，也可以在 `archive_wechat_file.py` 顶部填写：
 
-本程序对待备份的文件和已有的文件进行了名称和MD5值对比，从而避免文件的遗漏或重复备份。安全可靠，备份更省心。
+```python
+root_dir = "/path/to/your/wechat/files"
+target_path2 = "/path/to/your/archive"
+```
 
+`transit_path` 已不再需要。重名文件会直接复制到最终目标路径，不再经过中转目录。
 
+## 安全建议
 
-
+- 第一次运行前先使用 `--dry-run`。
+- 正式归档前尽量退出微信，或把 `--stable-seconds` 调大。
+- 不要把目标目录放在微信源目录内部，避免重复扫描。
+- 定期检查 `archive_wechat_file.log`，确认没有失败记录。

--- a/archive_wechat_file.py
+++ b/archive_wechat_file.py
@@ -1,144 +1,333 @@
-import os
-import time
-import shutil
+import argparse
 import hashlib
-import datetime
-import filecmp
-
-root_dir=(
-    ''  # 微信文件所在的路径，不用加/
-)
-
-transit_path = '' # 中转站的路径，最后要加上/
-target_path2 = '' # 用于存储复制过来的文件的目标目录，最后要加上/
-
-def TimeStampToTime(timestamp):
-    timeStruct = time.localtime(timestamp)
-    return time.strftime('%Y-%m', timeStruct)
+import logging
+import os
+import shutil
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import DefaultDict, Dict, Iterable, List, Optional, Set
 
 
-def get_change_time(file_path):
-    creation_time = TimeStampToTime(os.stat(file_path).st_ctime)
-    return creation_time
+# Legacy config values. You can still fill these in, but passing command line
+# arguments is safer because it keeps local paths out of source control.
+root_dir = ""
+target_path2 = ""
+
+# Deprecated: files are now copied directly to their final destination.
+transit_path = ""
+
+WECHAT_DIR_NAMES = {"File", "OpenData"}
+CHUNK_SIZE = 1024 * 1024
+DEFAULT_STABLE_SECONDS = 5
 
 
-def return_md5(file):
-    md5file = open(file, 'rb')
-    md5 = hashlib.md5(md5file.read()).hexdigest()
-    md5file.close()
-    return md5
+def timestamp_to_month(timestamp: float) -> str:
+    return time.strftime("%Y-%m", time.localtime(timestamp))
 
 
-def mkdir_target(riqi):
-    path = target_path2  # 目标文件
+def archive_month(file_path: Path) -> str:
+    stat_result = file_path.stat()
+    timestamp = getattr(stat_result, "st_birthtime", None)
+    if timestamp is None:
+        timestamp = stat_result.st_mtime
+    return timestamp_to_month(timestamp)
+
+
+def compute_md5(file_path: Path) -> str:
+    digest = hashlib.md5()
+    with file_path.open("rb") as file_obj:
+        for chunk in iter(lambda: file_obj.read(CHUNK_SIZE), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def ensure_month_dir(target_root: Path, month: str) -> Path:
+    target_dir = target_root / month
+    target_dir.mkdir(parents=True, exist_ok=True)
+    return target_dir
+
+
+def safe_resolve(path: Path) -> Path:
     try:
-        os.mkdir(path + str(riqi))
-    except:
-        pass
+        return path.resolve()
+    except OSError:
+        return path.absolute()
 
 
-def return_target_file_name(target_path):
-    # Returns filenames without the path
-    filenames = []
-    for path, dir_list, file_list in os.walk(target_path):
-        for file_name in file_list:
-            filenames.append(file_name)
-    return filenames
+def is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
 
 
-def scanning_file(source_path2):
-    """
-    source 是 mac 微信的路径
-    targee 是 目标 的路径
-    要检查的文件夹
-    """
-    file_tree = os.walk(source_path2)
-    for path, dir_list, source_file_list in file_tree:  # 第一个循环，遍历所有source文件
-        for source_file_list in source_file_list:  # 第二个循环，遍历所有souce文件名字
-
-            # 防止找不到riqi文件而直接跳过for导致报错
-            riqi = get_change_time(str(path) + '/' + str(source_file_list))
-            target_path = target_path2 + riqi
-            target_path_file_name = return_target_file_name(target_path)  # 获取目标文件夹内的文件名
-
-            status = 3
-            for i in target_path_file_name:
-                # 文件名相同
-                if i == source_file_list:
-                    md5_target = return_md5(target_path + '/' + i)
-                    md5_source = return_md5(path + '/' + source_file_list)
-
-                    # MD5相同（两个重名的文件
-                    if md5_target == md5_source:
-                        status = 2
-                        break
-
-                    # MD5不同（两个重名的文件
-                    else:
-                        status = 1
-                        break
-
-                else:
-                    status = 3
-            print(status)
-
-            """
-            status
-            1: 名字一样，md5不一样，重命名复制
-            2：名字一样，md5一样，跳过
-            3：名字不一样，直接复制
-            """
-            if status == 3:
-
-                mkdir_target(riqi)
-                target_path = target_path2 + riqi
-                try:
-                    shutil.copy2(str(path) + '/' + str(source_file_list), target_path)
-                except:
-                    print(source_file_list)
-                print('复制了：', source_file_list,target_path)
-
-            elif status == 1:
-                # 如果md5不一样而且名字一样
-                # file_list应该改名
-                num = source_file_list.find('.')
-                shijian = time.strftime("%Y_%m_%d_%H_%M_%S", time.localtime())
-
-                # 迁移到中转站
-                # 中转站路径
-                shutil.copy2(str(path) + '/' + str(source_file_list), transit_path + source_file_list)
-
-                # 在中转处重命名
-                file_list2 = transit_path + '/' + source_file_list[:num] + '_' + str(shijian) + source_file_list[
-                                                                                                num:]
-                file_name = source_file_list[:num] + '_' + str(shijian) + source_file_list[num:]
-                os.rename(str(transit_path) + '/' + source_file_list, file_list2)
-
-                # 复制重命名后到目标目录
-                mkdir_target(riqi)
-                try:
-                    shutil.move(str(transit_path) + '/' + str(file_name), target_path)
-                except:
-                    print(file_name)
-                print('重命名了：', file_name, md5_target, md5_source)
-            else:
-                print('跳过了', source_file_list)
-                pass
-
-
-def get_wechat_file_paths():
-    # 定义要扫描的目录，替换成你实际的目录
-
-    wechat_paths = []
-    for current_path, directories, files in os.walk(root_dir):
-        if 'File' in current_path or 'OpenData' in current_path:
-            wechat_paths.append(current_path)
+def get_wechat_file_paths(source_root: Path) -> List[Path]:
+    wechat_paths: List[Path] = []
+    for current_path, dir_names, _ in os.walk(str(source_root)):
+        current = Path(current_path)
+        if current.name in WECHAT_DIR_NAMES:
+            wechat_paths.append(current)
+            dir_names[:] = []
     return wechat_paths
 
 
-while 1:
-    work_path = get_wechat_file_paths()
-    print(work_path)
-    for i in range(len(work_path)):
-        scanning_file(work_path[i])
-    break
+def iter_source_files(source_roots: Iterable[Path]) -> Iterable[Path]:
+    seen: Set[Path] = set()
+    for source_root in source_roots:
+        for file_path in source_root.rglob("*"):
+            if not file_path.is_file():
+                continue
+
+            resolved = safe_resolve(file_path)
+            if resolved in seen:
+                continue
+
+            seen.add(resolved)
+            yield file_path
+
+
+def build_md5_index(
+    target_root: Path, exclude_paths: Optional[Set[Path]] = None
+) -> DefaultDict[str, List[Path]]:
+    md5_index: DefaultDict[str, List[Path]] = defaultdict(list)
+    exclude_paths = exclude_paths or set()
+
+    if not target_root.exists():
+        return md5_index
+
+    for file_path in target_root.rglob("*"):
+        if not file_path.is_file():
+            continue
+
+        if safe_resolve(file_path) in exclude_paths:
+            continue
+
+        try:
+            md5_index[compute_md5(file_path)].append(file_path)
+        except OSError as exc:
+            logging.warning("Could not index target file %s: %s", file_path, exc)
+
+    return md5_index
+
+
+def is_file_stable(file_path: Path, stable_seconds: float) -> bool:
+    if stable_seconds <= 0:
+        return True
+
+    try:
+        stat_result = file_path.stat()
+    except OSError as exc:
+        logging.warning("Could not stat source file %s: %s", file_path, exc)
+        return False
+
+    return (time.time() - stat_result.st_mtime) >= stable_seconds
+
+
+def unique_destination(
+    target_dir: Path,
+    source_name: str,
+    file_md5: str,
+    reserved_paths: Optional[Set[Path]] = None,
+) -> Path:
+    reserved_paths = reserved_paths or set()
+    source_path = Path(source_name)
+    suffix = source_path.suffix
+    stem = source_path.stem
+    if not stem:
+        stem = source_path.name
+
+    base_name = f"{stem}_{file_md5[:12]}"
+    candidate = target_dir / f"{base_name}{suffix}"
+    counter = 1
+    while candidate.exists() or safe_resolve(candidate) in reserved_paths:
+        candidate = target_dir / f"{base_name}_{counter}{suffix}"
+        counter += 1
+    return candidate
+
+
+def copy_file(source_file: Path, destination: Path, dry_run: bool) -> None:
+    if dry_run:
+        logging.info("[dry-run] copy %s -> %s", source_file, destination)
+        return
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_file, destination)
+
+
+def archive_files(
+    source_root: Path,
+    target_root: Path,
+    dry_run: bool = False,
+    stable_seconds: float = DEFAULT_STABLE_SECONDS,
+    exclude_paths: Optional[Set[Path]] = None,
+) -> Dict[str, int]:
+    source_root = safe_resolve(source_root)
+    target_root = safe_resolve(target_root)
+
+    if not source_root.exists():
+        raise FileNotFoundError(f"source root does not exist: {source_root}")
+
+    if not dry_run:
+        target_root.mkdir(parents=True, exist_ok=True)
+
+    exclude_paths = {safe_resolve(path) for path in (exclude_paths or set())}
+    exclude_paths.add(safe_resolve(target_root / "archive_wechat_file.log"))
+    md5_index = build_md5_index(target_root, exclude_paths=exclude_paths)
+    wechat_paths = get_wechat_file_paths(source_root)
+    target_root_resolved = safe_resolve(target_root)
+
+    if not wechat_paths:
+        logging.warning("No File/OpenData directories found under %s", source_root)
+
+    summary = {
+        "copied": 0,
+        "renamed": 0,
+        "skipped_duplicate": 0,
+        "skipped_unstable": 0,
+        "skipped_target": 0,
+        "failed": 0,
+    }
+    planned_destinations: Set[Path] = set()
+
+    for source_file in iter_source_files(wechat_paths):
+        source_resolved = safe_resolve(source_file)
+        if is_relative_to(source_resolved, target_root_resolved):
+            summary["skipped_target"] += 1
+            logging.info("Skip target file found during source scan: %s", source_file)
+            continue
+
+        if not is_file_stable(source_file, stable_seconds):
+            summary["skipped_unstable"] += 1
+            logging.info("Skip unstable source file: %s", source_file)
+            continue
+
+        try:
+            source_md5 = compute_md5(source_file)
+            if source_md5 in md5_index:
+                summary["skipped_duplicate"] += 1
+                logging.info(
+                    "Skip duplicate content: %s already exists at %s",
+                    source_file,
+                    md5_index[source_md5][0],
+                )
+                continue
+
+            month = archive_month(source_file)
+            if dry_run:
+                target_dir = target_root / month
+            else:
+                target_dir = ensure_month_dir(target_root, month)
+            destination = target_dir / source_file.name
+            renamed = False
+
+            if destination.exists() or safe_resolve(destination) in planned_destinations:
+                destination = unique_destination(
+                    target_dir, source_file.name, source_md5, planned_destinations
+                )
+                renamed = True
+
+            copy_file(source_file, destination, dry_run)
+            md5_index[source_md5].append(destination)
+            planned_destinations.add(safe_resolve(destination))
+
+            if renamed:
+                summary["renamed"] += 1
+                logging.info("Copied with new name: %s -> %s", source_file, destination)
+            else:
+                summary["copied"] += 1
+                logging.info("Copied: %s -> %s", source_file, destination)
+
+        except OSError as exc:
+            summary["failed"] += 1
+            logging.error("Failed to archive %s: %s", source_file, exc)
+
+    return summary
+
+
+def configure_logging(log_file: Optional[Path]) -> None:
+    handlers: List[logging.Handler] = [logging.StreamHandler()]
+    if log_file is not None:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        handlers.append(logging.FileHandler(log_file, encoding="utf-8"))
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+        handlers=handlers,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Archive Mac WeChat files by month with content de-duplication."
+    )
+    parser.add_argument("--root-dir", default=root_dir, help="WeChat data root path.")
+    parser.add_argument(
+        "--target-dir", default=target_path2, help="Archive destination root path."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned copies without writing files.",
+    )
+    parser.add_argument(
+        "--stable-seconds",
+        type=float,
+        default=DEFAULT_STABLE_SECONDS,
+        help="Skip source files modified within this many seconds.",
+    )
+    parser.add_argument(
+        "--log-file",
+        default=None,
+        help="Optional log file path. Defaults to <target-dir>/archive_wechat_file.log.",
+    )
+    return parser
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    return build_parser().parse_args(argv)
+
+
+def validate_path_arg(parser: argparse.ArgumentParser, value: str, name: str) -> Path:
+    if not value:
+        parser.error(
+            f"{name} is required. Pass it as an argument or set it in the file."
+        )
+    return Path(value).expanduser()
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    source_root = validate_path_arg(parser, args.root_dir, "--root-dir")
+    target_root = validate_path_arg(parser, args.target_dir, "--target-dir")
+
+    if args.log_file:
+        log_file = Path(args.log_file).expanduser()
+    elif args.dry_run:
+        log_file = None
+    else:
+        log_file = target_root / "archive_wechat_file.log"
+    configure_logging(log_file)
+
+    try:
+        summary = archive_files(
+            source_root=source_root,
+            target_root=target_root,
+            dry_run=args.dry_run,
+            stable_seconds=args.stable_seconds,
+            exclude_paths={safe_resolve(log_file)} if log_file else None,
+        )
+    except Exception as exc:
+        logging.error("Archive failed: %s", exc)
+        return 1
+
+    logging.info("Summary: %s", summary)
+    return 1 if summary["failed"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_archive_wechat_file.py
+++ b/tests/test_archive_wechat_file.py
@@ -1,0 +1,88 @@
+import shutil
+import unittest
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+
+from archive_wechat_file import archive_files, archive_month
+
+
+@contextmanager
+def local_temp_dir():
+    temp_root = Path.cwd() / ".test_tmp" / uuid.uuid4().hex
+    temp_root.mkdir(parents=True)
+    try:
+        yield temp_root
+    finally:
+        shutil.rmtree(temp_root, ignore_errors=True)
+
+
+class ArchiveWechatFileTests(unittest.TestCase):
+    def test_duplicate_content_with_different_name_is_skipped(self):
+        with local_temp_dir() as base:
+            source_dir = base / "wechat" / "File"
+            target_dir = base / "archive"
+            source_dir.mkdir(parents=True)
+
+            duplicate_source = source_dir / "different-name.txt"
+            duplicate_source.write_text("same content", encoding="utf-8")
+
+            month = archive_month(duplicate_source)
+            target_month = target_dir / month
+            target_month.mkdir(parents=True)
+            (target_month / "already-archived.txt").write_text(
+                "same content", encoding="utf-8"
+            )
+
+            summary = archive_files(
+                base / "wechat", target_dir, dry_run=False, stable_seconds=0
+            )
+
+            self.assertEqual(summary["skipped_duplicate"], 1)
+            self.assertFalse((target_month / "different-name.txt").exists())
+
+    def test_same_name_different_content_is_copied_with_unique_name(self):
+        with local_temp_dir() as base:
+            source_dir = base / "wechat" / "File"
+            target_dir = base / "archive"
+            source_dir.mkdir(parents=True)
+
+            source_file = source_dir / "report.final.txt"
+            source_file.write_text("new content", encoding="utf-8")
+
+            month = archive_month(source_file)
+            target_month = target_dir / month
+            target_month.mkdir(parents=True)
+            (target_month / "report.final.txt").write_text(
+                "old content", encoding="utf-8"
+            )
+
+            summary = archive_files(
+                base / "wechat", target_dir, dry_run=False, stable_seconds=0
+            )
+
+            self.assertEqual(summary["renamed"], 1)
+            archived_files = sorted(path.name for path in target_month.iterdir())
+            self.assertEqual(len(archived_files), 2)
+            self.assertIn("report.final.txt", archived_files)
+            self.assertTrue(
+                any(name.startswith("report.final_") for name in archived_files)
+            )
+
+    def test_dry_run_does_not_create_target_files(self):
+        with local_temp_dir() as base:
+            source_dir = base / "wechat" / "File"
+            target_dir = base / "archive"
+            source_dir.mkdir(parents=True)
+            (source_dir / "message.txt").write_text("hello", encoding="utf-8")
+
+            summary = archive_files(
+                base / "wechat", target_dir, dry_run=True, stable_seconds=0
+            )
+
+            self.assertEqual(summary["copied"], 1)
+            self.assertFalse(target_dir.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace fragile string-based path handling and silent failures with a pathlib/logging based archive flow
- add content-based MD5 indexing, chunked hashing, dry-run support, and unstable-file skipping
- remove the transit directory copy path and add regression tests for dedupe, rename-on-conflict, and dry-run behavior
- update README usage to document the new CLI and safety guidance

## Why
The original script could silently report successful copies after failures, repeatedly hash large files inefficiently, and only dedupe same-name files. This makes real WeChat backup runs slow and risky, especially with large or actively-written files.

This addresses the core performance concern in #1 without switching to a short non-content hash.

## Validation
- `python -m py_compile archive_wechat_file.py tests\test_archive_wechat_file.py`
- `python -m unittest discover -s tests -v`
- `python archive_wechat_file.py --help`
